### PR TITLE
Remove jcenter from repositories.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,6 @@ allprojects // subprojects
     repositories {
         // standard
         mavenCentral()
-        jcenter()
 
         // local mavan cache
         mavenLocal()


### PR DESCRIPTION
Fetch from jcenter keeps failing.
See 
https://developer.android.com/studio/build/jcenter-migration
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/