### PR TITLE
RDKBDEV-2988: Fix memory leaks in "zilker-sdk"

### DIFF
--- a/source/integrations/xbb/libxbb/src/xbb.c
+++ b/source/integrations/xbb/libxbb/src/xbb.c
@@ -497,7 +497,7 @@ bool xbbGetConfig(XbbConfiguration *config)
         {
             DEBUG_PRINT("xbbGetConfig: Unable to retrieve DeviceTempAlarmMask\n");
         }
-
+        cJSON_Delete(json);
         return true;
     }
     else

--- a/source/libs/cslt/src/sheens/sheens_transcoder_triggers.c
+++ b/source/libs/cslt/src/sheens/sheens_transcoder_triggers.c
@@ -1126,10 +1126,14 @@ static cJSON* time_trigger_handler(const icrule_trigger_t* trigger,
                                                     node_branches);
         if (interval_javascript == NULL || endTimeJs == NULL)
         {
+            free(whenTimeJs);
             return NULL;
         }
 
         AUTO_CLEAN(free_generic__auto) char *intervalConditionJs = stringBuilder(interval_match_js, endTimeJs, interval_javascript);
+
+        free(endTimeJs);
+        free(interval_javascript);
 
         // Build the final javascript for interval rules
         js = stringBuilder(time_js, whenTimeJs, intervalConditionJs);
@@ -1139,6 +1143,8 @@ static cJSON* time_trigger_handler(const icrule_trigger_t* trigger,
         // Build the final javascript for exact time triggers
         js = stringBuilder(time_js, whenTimeJs, exact_match_js);
     }
+
+    free(whenTimeJs);
 
     if (js == NULL)
     {
@@ -1160,6 +1166,7 @@ static cJSON* time_trigger_handler(const icrule_trigger_t* trigger,
     cJSON_AddItemToObject(nodes_object,
                           uuid_str,
                           sheens_create_state_node(cJSON_CreateString(js), branch_array, false));
+    free(js);
 
     // Create schedule timer tick pattern for start.
     pattern = cJSON_CreateObject();

--- a/source/libs/zhal/c/src/zhalImpl.c
+++ b/source/libs/zhal/c/src/zhalImpl.c
@@ -533,6 +533,7 @@ static bool xmit(WorkItem *item)
     {
         icLogError(LOG_TAG, "error sending payload length: %s", strerror(errno));
         close(sock);
+        free(payload);
         return false;
     }
 

--- a/source/services/device/core/deviceDrivers/xbb/xbbDeviceDriver.c
+++ b/source/services/device/core/deviceDrivers/xbb/xbbDeviceDriver.c
@@ -823,6 +823,7 @@ static bool executeEndpointResource(ZigbeeDriverCommon *ctx,
             free(onPhaseDuration);
             free(offPhaseDuration);
             free(pauseDuration);
+            cJSON_Delete(inputObject);
         }
         else
         {

--- a/source/services/rdkIntegration/src/parodus_interface.c
+++ b/source/services/rdkIntegration/src/parodus_interface.c
@@ -608,6 +608,7 @@ void* sendNotification(void* pValue)
 
             notifyPayloadString = cJSON_PrintUnformatted(notifyPayload);
             icLogInfo(LOG_TAG, "payload: %s", notifyPayloadString);
+            free(notifyPayloadString);
         }
 
         snprintf(source, sizeof(source), "mac:%s/xhfw", deviceMAC);

--- a/tools/automationTool/src/automationUtil.c
+++ b/tools/automationTool/src/automationUtil.c
@@ -1217,7 +1217,6 @@ static automationMetadata *assembleAutomationMetadata(const char *disassemblyPat
                     default:
                         break;
                 }
-
                 free(metadataContents);
             }
         }


### PR DESCRIPTION
Reason for change: Fix memory leaks related to the usage of cJSON_Parse and cJSONPrint.
Test Procedure: Expected result - No memory leaks for cJSON_Parse and cJSONPrint..
Risks: Low

Change-Id: I6ad590f595aa6fca30c0fdc444c4b4052b7a8b16