### PR TITLE
RDKBDEV-2988: Fix memory leaks in "zilker-sdk"

### DIFF
--- a/source/integrations/xbb/libxbb/src/xbb.c
+++ b/source/integrations/xbb/libxbb/src/xbb.c
@@ -497,7 +497,7 @@ bool xbbGetConfig(XbbConfiguration *config)
         {
             DEBUG_PRINT("xbbGetConfig: Unable to retrieve DeviceTempAlarmMask\n");
         }
-
+        cJSON_Delete(json);
         return true;
     }
     else

--- a/source/libs/zhal/c/src/zhalImpl.c
+++ b/source/libs/zhal/c/src/zhalImpl.c
@@ -533,6 +533,7 @@ static bool xmit(WorkItem *item)
     {
         icLogError(LOG_TAG, "error sending payload length: %s", strerror(errno));
         close(sock);
+        free(payload);
         return false;
     }
 

--- a/source/services/device/core/deviceDrivers/xbb/xbbDeviceDriver.c
+++ b/source/services/device/core/deviceDrivers/xbb/xbbDeviceDriver.c
@@ -823,6 +823,7 @@ static bool executeEndpointResource(ZigbeeDriverCommon *ctx,
             free(onPhaseDuration);
             free(offPhaseDuration);
             free(pauseDuration);
+            cJSON_Delete(inputObject);
         }
         else
         {


### PR DESCRIPTION
Reason for change: Fix memory leaks related to the usage of cJSON_Parse and cJSONPrint.
Test Procedure: Expected result - No memory leaks for cJSON_Parse and cJSONPrint..
Risks: Low

Change-Id: I6ad590f595aa6fca30c0fdc444c4b4052b7a8b16